### PR TITLE
Formatted prices plus option to superscript third decimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ views:
 | `show_closed` | Boolean           | no       | Show closed stations (default: false)
 | `show_header` | Boolean           | no       | Show card-header (default: true)
 | `show_sup`    | Boolean           | no       | Show superscript third decimal place in prices (default: false)
+| `icon_closed` | String            | no       | Icon for closed stations (default: mdi:lock-outline)
+| `show_unknown`| String            | no       | Icon for unknown states (default: mdi:minus)
 | `stations`    | List of stations  | yes      | List of stations
 
 #### Stations

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ views:
           - e10
         show_closed: true
         show_header: false
+        show_sup: true
         stations:
           - name: Kölner Str.
             brand: ARAL
@@ -40,6 +41,7 @@ views:
 | `show`        | [e5, e10, diesel] | yes      | What should be shown
 | `show_closed` | Boolean           | no       | Show closed stations (default: false)
 | `show_header` | Boolean           | no       | Show card-header (default: true)
+| `show_sup`    | Boolean           | no       | Show superscript third decimal place in prices (default: false)
 | `stations`    | List of stations  | yes      | List of stations
 
 #### Stations

--- a/tankerkoenig-card.js
+++ b/tankerkoenig-card.js
@@ -91,6 +91,16 @@ class TankerkoenigCard extends LitElement {
         
         return false;
     }
+
+    isClosed(station) {
+        const state = this.getStationState(station);
+        
+        if(state && state.attributes.is_open == false) {
+            return true;
+        }
+        
+        return false;
+    }
     
     renderPrice(station, type) {
         if(!this.has[type]) {
@@ -100,16 +110,21 @@ class TankerkoenigCard extends LitElement {
         const state = this.hass.states[station[type]] || null;
             
         if(state && state.state != 'unknown' && state.state != 'unavailable' && this.isOpen(station)) {
+            const price = parseFloat(state.state).toLocaleString(undefined, {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+            });
+            const sup = this.config.show_sup ? state.state.substr(state.state.indexOf('.') + 3) : '';
             return html`<td><ha-label-badge
               label="${type.toUpperCase()}"
               @click="${() => this.fireEvent('hass-more-info', station[type])}"
-              ><span style="font-size: 75%;">${state.state}&euro;</span></ha-label-badge></td>`;
+              ><span>${price}<sup>${sup}</sup>&euro;</span></ha-label-badge></td>`;
         } else {
+            const icon = this.isClosed(station) ? 'mdi:sleep' : 'mdi:minus';
             return html`<td><ha-label-badge
-              icon="mdi:lock-outline"
               label="${type.toUpperCase()}"
               @click="${() => this.fireEvent('hass-more-info', station[type])}"
-              ></ha-label-badge></td>`;
+              ><ha-icon icon="${icon}"/></ha-label-badge></td>`;
         }
     }
     
@@ -153,7 +168,9 @@ class TankerkoenigCard extends LitElement {
             td.name { text-align: left; font-weight: bold; }
             td.gasstation img { vertical-align: middle; }
             ha-label-badge { font-size: 85%; }
+            ha-label-badge span { font-size: 75%; position: relative; top: -3px;}
             .label-badge .value { font-size: 70%; }
+            ha-icon { position: relative; top: -3px; --mdc-icon-size: 20px;  height: 20px; width: 20px; }
         `;
     }
 }

--- a/tankerkoenig-card.js
+++ b/tankerkoenig-card.js
@@ -120,7 +120,9 @@ class TankerkoenigCard extends LitElement {
               @click="${() => this.fireEvent('hass-more-info', station[type])}"
               ><span>${price}<sup>${sup}</sup>&euro;</span></ha-label-badge></td>`;
         } else {
-            const icon = this.isClosed(station) ? 'mdi:sleep' : 'mdi:minus';
+            const icon_closed = this.config.icon_closed ?? 'mdi:lock-outline';
+            const icon_unknown = this.config.icon_unknown ?? 'mdi:minus';
+            const icon = this.isClosed(station) ? icon_closed : icon_unknown;
             return html`<td><ha-label-badge
               label="${type.toUpperCase()}"
               @click="${() => this.fireEvent('hass-more-info', station[type])}"

--- a/tankerkoenig-card.js
+++ b/tankerkoenig-card.js
@@ -120,8 +120,8 @@ class TankerkoenigCard extends LitElement {
               @click="${() => this.fireEvent('hass-more-info', station[type])}"
               ><span>${price}<sup>${sup}</sup>&euro;</span></ha-label-badge></td>`;
         } else {
-            const icon_closed = this.config.icon_closed ?? 'mdi:lock-outline';
-            const icon_unknown = this.config.icon_unknown ?? 'mdi:minus';
+            const icon_closed = this.config.icon_closed || 'mdi:lock-outline';
+            const icon_unknown = this.config.icon_unknown || 'mdi:minus';
             const icon = this.isClosed(station) ? icon_closed : icon_unknown;
             return html`<td><ha-label-badge
               label="${type.toUpperCase()}"


### PR DESCRIPTION
- Formatted the price to show only two decimal places. The third can be shown by using the `show_sup: true` option.
- Fixed the icon and added option to define custom icons for closed stations and unknown states with defaults: `mdi:lock-outline` for closed station and `mdi:minus` for unknown state.

![Card](https://user-images.githubusercontent.com/2835495/150611372-14b9f63e-d9a2-4c7c-9973-5d6f009ecb65.png)
